### PR TITLE
Update kotatsu-dl.bat

### DIFF
--- a/kotatsu-dl.bat
+++ b/kotatsu-dl.bat
@@ -1,1 +1,1 @@
-start javaw -jar kotatsu-dl.jar
+start javaw -jar kotatsu-dl-0.3.jar


### PR DESCRIPTION
Fix error "Unable to access jarfile kotatsu-dl.jar" due to mismatch .jar name