### PR TITLE
Fix error fetching file extensions for some sites and increase manga dialog's size.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 kotlin.code.style=official
-kotlin.version=1.9.22
-compose.version=1.5.12
+kotlin.version=1.9.20
+compose.version=1.5.10

--- a/src/jvmMain/kotlin/org/koitharu/kotatsu_dl/logic/downloader/DownloadTask.kt
+++ b/src/jvmMain/kotlin/org/koitharu/kotatsu_dl/logic/downloader/DownloadTask.kt
@@ -45,6 +45,7 @@ class DownloadTask(
 			val coverUrl = data.largeCoverUrl ?: data.coverUrl
 			downloadFile(coverUrl, data.source).let { file ->
 				output.addCover(file, getFileExtensionFromUrl(coverUrl))
+
 			}
 			val chapters = if (chaptersIds == null) {
 				data.chapters.orEmpty()
@@ -65,6 +66,7 @@ class DownloadTask(
 									pageIndex,
 									getFileExtensionFromUrl(url),
 								)
+								getFileExtensionFromUrl(url)
 							} catch (e: IOException) {
 								continue@failsafe
 							}
@@ -132,7 +134,7 @@ class DownloadTask(
 	}
 
 	private fun getFileExtensionFromUrl(url: String): String {
-		return url.substringAfterLast('.', "")
+		return url.substringAfterLast('.', "").take(3)
 	}
 
 	private companion object {

--- a/src/jvmMain/kotlin/org/koitharu/kotatsu_dl/logic/downloader/DownloadTask.kt
+++ b/src/jvmMain/kotlin/org/koitharu/kotatsu_dl/logic/downloader/DownloadTask.kt
@@ -134,7 +134,7 @@ class DownloadTask(
 	}
 
 	private fun getFileExtensionFromUrl(url: String): String {
-		return url.substringAfterLast('.', "").take(3)
+		return url.substringBeforeLast('?').substringAfterLast('.', "")
 	}
 
 	private companion object {

--- a/src/jvmMain/kotlin/org/koitharu/kotatsu_dl/ui/LocalResources.kt
+++ b/src/jvmMain/kotlin/org/koitharu/kotatsu_dl/ui/LocalResources.kt
@@ -4,9 +4,7 @@ import androidx.compose.runtime.compositionLocalOf
 import java.util.*
 
 class Resources {
-
 	private val bundle = ResourceBundle.getBundle("messages")
-
 	fun string(name: String): String = bundle.getString(name)
 }
 

--- a/src/jvmMain/kotlin/org/koitharu/kotatsu_dl/ui/screens/Window.kt
+++ b/src/jvmMain/kotlin/org/koitharu/kotatsu_dl/ui/screens/Window.kt
@@ -3,7 +3,6 @@ package org.koitharu.kotatsu_dl.ui.screens
 import androidx.compose.runtime.Composable
 
 interface Window {
-
 	@Composable
 	operator fun invoke()
 }

--- a/src/jvmMain/kotlin/org/koitharu/kotatsu_dl/ui/screens/list/MangaListWindow.kt
+++ b/src/jvmMain/kotlin/org/koitharu/kotatsu_dl/ui/screens/list/MangaListWindow.kt
@@ -202,7 +202,7 @@ class MangaListWindow(
 			content.isNotEmpty() -> {
 				LazyVerticalGrid(
 					modifier = Modifier.padding(horizontal = 6.dp),
-					columns = GridCells.Adaptive(minSize = 98.dp),
+					columns = GridCells.Adaptive(minSize = 142.dp),
 					state = listState,
 				) {
 					items(content) { manga ->

--- a/src/jvmMain/kotlin/org/koitharu/kotatsu_dl/ui/screens/settings/SettingsDialog.kt
+++ b/src/jvmMain/kotlin/org/koitharu/kotatsu_dl/ui/screens/settings/SettingsDialog.kt
@@ -2,7 +2,6 @@ package org.koitharu.kotatsu_dl.ui.screens.settings
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -51,11 +50,13 @@ class SettingsDialog(
 				},
 				items = listOf(
 					resources.string("system_default"),
-					resources.string("light"),
+ 					resources.string("light"),
 					resources.string("dark"),
 				),
 				style = MaterialTheme.typography.titleMedium,
 			)
+
+
 			Spacer(modifier = Modifier.weight(1f))
 			Row(
 				modifier = Modifier


### PR DESCRIPTION
Here is the list of errors:
- For some sites when fetching, the `getFileExtensionFromUrl(url: String)` returns a new string including the file extension and image id. 
![2024-04-05-06:44:58-screenshot](https://github.com/KotatsuApp/kotatsu-dl/assets/151365241/80656ff3-8e15-406f-9b2b-2439258a3caf)
- When I let `MangaListWindow` load normally it takes a long time and is quite laggy,  and in fullscreen mode, the number of Manga displayed is too much and the Manga Box is too small.