### PR TITLE
Fix directory and file creation logic in createDirs

### DIFF
--- a/src/jvmMain/kotlin/org/koitharu/kotatsu_dl/data/Directories.kt
+++ b/src/jvmMain/kotlin/org/koitharu/kotatsu_dl/data/Directories.kt
@@ -27,14 +27,16 @@ object Directories {
 	val configFile = config / "kotatsu-dl-config.yml"
 
 	fun createDirs() {
-		if (config.exists()) {
-			if (!configFile.exists()) {
-				configFile.createFile()
-			} else {
-				println("The config file has been created.")
-			}
-		} else {
+		// Create the directory if it does not exist
+		if (!config.exists()) {
 			config.createDirectories()
+		}
+
+		// Create the configuration file if it does not exist
+		if (!configFile.exists()) {
+			configFile.createFile()
+		} else {
+			println("The config file has already been created.")
 		}
 	}
 }


### PR DESCRIPTION
**Issue:** configFile.createFile() was only executed if config existed. If config didn’t exist, configFile.createFile() was not reached.

**Fix:** Ensured config directory is created if missing, then configFile is created regardless of the directory state.

This should fix the following Problems:
- https://github.com/KotatsuApp/kotatsu-dl/issues/12
- https://github.com/KotatsuApp/kotatsu-dl/issues/7
- https://github.com/KotatsuApp/kotatsu-dl/issues/8